### PR TITLE
better error message when rabbitmq-server isn't running.

### DIFF
--- a/lib/firehose/cli.rb
+++ b/lib/firehose/cli.rb
@@ -10,7 +10,12 @@ module Firehose
       server = Thin::Server.new(options[:host], options[:port]) do
         run Firehose::Rack::App.new
       end
-      server.start!
+
+      begin
+        server.start!
+      rescue AMQP::TCPConnectionFailed => e
+        Firehose.logger.error "Unable to connect to AMQP, are you sure it's running?"
+      end
     end
   end
 end


### PR DESCRIPTION
After there are different backends, should probably abstract this to a
Firehose::ConnectionError. There's a corresponding pull request to update the
docs in the hombrew package.
https://github.com/mxcl/homebrew/pull/11932/files
