### PR TITLE
Requires firehose/rails immediately if Rails::Engine is defined

### DIFF
--- a/lib/firehose.rb
+++ b/lib/firehose.rb
@@ -3,12 +3,13 @@ require 'firehose/version'
 require 'em-hiredis'
 require 'logger'
 
+require 'firehose/rails' if defined?(::Rails::Engine)
+
 module Firehose
   autoload :Subscription, 'firehose/subscription'
   autoload :Publisher,    'firehose/publisher'
   autoload :Producer,     'firehose/producer'
   autoload :Default,      'firehose/default'
-  autoload :Rails,        'firehose/rails'
   autoload :Rack,         'firehose/rack'
   autoload :CLI,          'firehose/cli'
   


### PR DESCRIPTION
By requiring firehose/rails directly from firehose.rb asset pipeline includes work out of the box. The guard should prevent this from breaking in non-Rails environments.
