### PR TITLE
add 'rainbows' gem to gemspec

### DIFF
--- a/firehose.gemspec
+++ b/firehose.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "em-http-request", ">= 1.0.0"
   s.add_runtime_dependency "json"
   s.add_runtime_dependency "rack", "~> 1.4.0"
+  s.add_runtime_dependency "rainbows", "~> 4.5.0"
 
   s.add_development_dependency "rspec"
   s.add_development_dependency "webmock"


### PR DESCRIPTION
ran `gem install firehose` and then `firehose server` - but got an error: 

`cannot load such file -- rainbows (LoadError)`

After installing the `rainbows` gem, things worked fine.

Adding to gemspec so that it can be installed and run w/out the manual rainbows installation.
