### PR TITLE
Support webpack builds

### DIFF
--- a/javascript/index.js
+++ b/javascript/index.js
@@ -1,3 +1,4 @@
-require("coffee-script/register");
+if ("webpack" != process.env.NODE_ENV) {
+  require("coffee-script/register");
+}
 module.exports = require("./lib/firehose");
-

--- a/javascript/lib/globals.coffee
+++ b/javascript/lib/globals.coffee
@@ -6,6 +6,9 @@ jsdom = require("jsdom")
 global.document = jsdom.jsdom("<html></html>")
 global.window = document.defaultView
 
+# Node environments need this, browsers implement it themselves
+global.WebSocket = require "ws"
+
 # URIjs dependencies
 
 # Set a location so that URIjs behaves correctly

--- a/javascript/lib/web_socket_transport.coffee
+++ b/javascript/lib/web_socket_transport.coffee
@@ -1,5 +1,4 @@
 Transport = require "./transport"
-WebSocket = require "ws"
 
 INITIAL_PING_TIMEOUT   =  2000
 KEEPALIVE_PING_TIMEOUT = 20000
@@ -7,11 +6,14 @@ KEEPALIVE_PING_TIMEOUT = 20000
 sendPing = (socket) ->
   socket.send JSON.stringify ping: 'PING'
 
+getWebSocket = ->
+  window?.WebSocket || global?.WebSocket
+
 class WebSocketTransport extends Transport
   name: -> 'WebSocket'
 
   @ieSupported:-> (document.documentMode || 10) > 9
-  @supported  :-> WebSocket? # Check if WebSocket is an object in the window.
+  @supported  :-> !!getWebSocket() # Check if WebSocket is an object in the window.
 
   constructor: (args) ->
     super args
@@ -26,7 +28,7 @@ class WebSocketTransport extends Transport
     # Run this in a try/catch block because IE10 inside of a .NET control
     # complains about security zones.
     try
-      @socket = new WebSocket "#{@_protocol()}:#{@config.uri}?#{$.param @_requestParams()}"
+      @socket = new getWebSocket()("#{@_protocol()}:#{@config.uri}?#{$.param @_requestParams()}")
       @socket.onopen    = @_open
       @socket.onclose   = @_close
       @socket.onerror   = @_error


### PR DESCRIPTION
Webpack handles coffeescript itself, and the browser defines `WebSocket` so the `ws` module is not needed (and does not work) in browsers.