### PR TITLE
Use `String#bytesize` for `Content-Length` instead of `String#size`

### DIFF
--- a/lib/firehose/rack.rb
+++ b/lib/firehose/rack.rb
@@ -25,7 +25,7 @@ module Firehose
       # Calculates the content of a message body for the response so that HTTP Keep-Alive
       # connections work.
       def response(status, body='', headers={})
-        headers = {'Content-Length' => body.size.to_s}.merge(headers)
+        headers = {'Content-Length' => body.bytesize.to_s}.merge(headers)
         [status, headers, [body]]
       end
     end

--- a/lib/firehose/rack/publisher.rb
+++ b/lib/firehose/rack/publisher.rb
@@ -42,7 +42,7 @@ module Firehose
         else
           Firehose.logger.debug "HTTP #{method} not supported"
           msg = "#{method} not supported."
-          [501, {'Content-Type' => 'text/plain', 'Content-Length' => msg.size.to_s}, [msg]]
+          [501, {'Content-Type' => 'text/plain', 'Content-Length' => msg.bytesize.to_s}, [msg]]
         end
       end
 


### PR DESCRIPTION
`String#size` returns the character count with multi-byte characters counting as 1. However, Content-Length is expecting the length of the body in bytes. `String#bytesize` is the correct method to use here. 