### PR TITLE
Handle buffer_size 0 correctly

### DIFF
--- a/lib/firehose/server/publisher.rb
+++ b/lib/firehose/server/publisher.rb
@@ -118,7 +118,7 @@ module Firehose
         local channel_key       = KEYS[3]
         local ttl               = KEYS[4]
         local message           = KEYS[5]
-        local buffer_size       = KEYS[6]
+        local buffer_size       = KEYS[6] + 0
         local persist           = KEYS[7] == "true"
         local payload_delimiter = KEYS[8]
         local firehose_resource = KEYS[9]
@@ -132,8 +132,13 @@ module Firehose
         local message_payload = firehose_resource .. payload_delimiter .. sequence .. payload_delimiter .. message
 
         redis.call('set', sequence_key, sequence)
-        redis.call('lpush', list_key, message)
-        redis.call('ltrim', list_key, 0, buffer_size - 1)
+        if buffer_size > 0 then
+          redis.call('lpush', list_key, message)
+          redis.call('ltrim', list_key, 0, buffer_size - 1)
+        else
+          redis.call('del', list_key)
+        end
+
         redis.call('publish', channel_key, message_payload)
 
         if persist then

--- a/spec/lib/server/publisher_spec.rb
+++ b/spec/lib/server/publisher_spec.rb
@@ -62,6 +62,17 @@ describe Firehose::Server::Publisher do
       redis_exec('llen', "firehose:#{channel_key}:list").should == buffer_size
     end
 
+    it "stores no messages if buffer size is 0" do
+      buffer_size = 0
+      em do
+        Firehose::Server::MessageBuffer::DEFAULT_SIZE.times do |n|
+          publisher.publish(channel_key, message)
+        end
+        publisher.publish(channel_key, message, buffer_size: buffer_size).callback { em.stop }
+      end
+      redis_exec('llen', "firehose:#{channel_key}:list").should == buffer_size
+    end
+
     it "increments sequence" do
       sequence_key = "firehose:#{channel_key}:sequence"
 


### PR DESCRIPTION
Previously, if buffer_size was set to 0, we would execute
```
LTRIM list_key 0 -1
```
which keeps the entire list (LTRIM's arguments specify the range to
keep, inclusive, and the indices wrap so that -1 represents the last
element).