### PR TITLE
Add handling for JSON parser errors

### DIFF
--- a/lib/firehose/rack/consumer.rb
+++ b/lib/firehose/rack/consumer.rb
@@ -78,6 +78,9 @@ module Firehose
         end
 
         subs
+      rescue JSON::ParserError
+        Firehose.logger.warn "Consumer.post_subscriptions: JSON::ParserError for request body: #{body.inspect}"
+        []
       end
 
       # Let the client configure the consumer on initialization.


### PR DESCRIPTION
Poll Everywhere has been seeing large numbers of `JSON::ParserError`s in
spikes, and our error tracker has been unhelpful in identifying the
source.